### PR TITLE
Group endlessos.org and endlessm.com together

### DIFF
--- a/projects/gnome-meta.json
+++ b/projects/gnome-meta.json
@@ -70,9 +70,10 @@
             ]
         },
         {
-            "name": "endlessm.com",
+            "name": "endlessos.org",
             "aggregate_emails":
             [
+                { "pattern": "*endlessm.com" },
                 { "pattern": "*mecheye.net",
                   "begin": { "year": 2014, "month": 10 },
                   "end":   { "year": 2017, "month": 2 } }


### PR DESCRIPTION
Endless transformed into a non-profit foundation this year and we have a new domain to go with it.

Make endlessos.org the primary domain and match endlessm.com for its long history (and because not everybody has updated their Git configuration yet).