### PR TITLE
Style fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,14 @@ authors = ["Hans Petter Jansson <hpj@hpjansson.org>"]
 edition = "2018"
 
 [dependencies]
-io = "0.0"
 chrono = "0.4"
-regex = "1.3"
 error-chain = "0.12"
+io = "0.0"
+itertools = "0.9"
+regex = "1.3"
+serde_json = "1.0"
 structopt = "0.3"
 tempfile = "3.1"
-serde_json = "1.0"
 
 [dependencies.rusqlite]
 version = "0.24"

--- a/src/cohorthist.rs
+++ b/src/cohorthist.rs
@@ -279,3 +279,47 @@ impl CohortHist
             .join("\n")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn without_month_next() {
+        assert_eq!(
+            YearMonth {
+                year: 2020,
+                month: NO_MONTH,
+            }.next(),
+            YearMonth {
+                year: 2021,
+                month: NO_MONTH,
+            },
+        );
+    }
+
+    #[test]
+    fn with_month_next() {
+        assert_eq!(
+            YearMonth {
+                year: 2020,
+                month: 0,
+            }.next(),
+            YearMonth {
+                year: 2020,
+                month: 1,
+            },
+        );
+
+        assert_eq!(
+            YearMonth {
+                year: 2020,
+                month: 11,
+            }.next(),
+            YearMonth {
+                year: 2021,
+                month: 0,
+            },
+        );
+    }
+}

--- a/src/cohorthist.rs
+++ b/src/cohorthist.rs
@@ -322,4 +322,35 @@ mod tests {
             },
         );
     }
+
+    #[test]
+    fn ym_begin() {
+        assert_eq!(
+            YearMonth { year: 2020, month: NO_MONTH }.begin_dt(),
+            NaiveDate::from_ymd(2020, 1, 1).and_hms(0, 0, 0),
+        );
+
+        assert_eq!(
+            YearMonth { year: 2020, month: 11 }.begin_dt(),
+            NaiveDate::from_ymd(2020, 12, 1).and_hms(0, 0, 0),
+        );
+    }
+
+    #[test]
+    fn ym_end() {
+        assert_eq!(
+            YearMonth { year: 2020, month: NO_MONTH }.end_dt(),
+            NaiveDate::from_ymd(2021, 1, 1).and_hms(0, 0, 0),
+        );
+
+        assert_eq!(
+            YearMonth { year: 2020, month: 0 }.end_dt(),
+            NaiveDate::from_ymd(2020, 2, 1).and_hms(0, 0, 0),
+        );
+
+        assert_eq!(
+            YearMonth { year: 2020, month: 11 }.end_dt(),
+            NaiveDate::from_ymd(2021, 1, 1).and_hms(0, 0, 0),
+        );
+    }
 }

--- a/src/cohorthist.rs
+++ b/src/cohorthist.rs
@@ -39,25 +39,13 @@ impl YearMonth
 {
     pub fn next(&self) -> YearMonth
     {
-        let mut ym = YearMonth { year: -1, month: -1 };
+        let YearMonth { year, month } = *self;
 
-        if self.month == NO_MONTH
-        {
-            ym.year = self.year + 1;
-            ym.month = NO_MONTH;
+        match month {
+            NO_MONTH => YearMonth { year: year + 1, month: NO_MONTH },
+            11 => YearMonth { year: year + 1, month: 0 },
+            m => YearMonth { year, month: m + 1 },
         }
-        else if self.month == 11
-        {
-            ym.year = self.year + 1;
-            ym.month = 0;
-        }
-        else
-        {
-            ym.year = self.year;
-            ym.month = self.month + 1;
-        }
-
-        ym
     }
 
     pub fn begin_dt(&self) -> NaiveDateTime
@@ -68,24 +56,15 @@ impl YearMonth
 
     pub fn end_dt(&self) -> NaiveDateTime
     {
-        if self.month == NO_MONTH
-        {
-            NaiveDate::from_ymd(self.year + 1, 1, 1).and_hms(0, 0, 0)
-        }
-        else
-        {
-            let (y, m) =
-                if self.month == 11
-                {
-                    (self.year + 1, 1)
-                }
-                else
-                {
-                    (self.year, self.month + 2)
-                };
+        let YearMonth { year, month } = *self;
 
-            NaiveDate::from_ymd(y, m as u32, 1).and_hms(0, 0, 0)
-        }
+        let date = match month {
+            NO_MONTH => NaiveDate::from_ymd(year + 1, 1, 1),
+            11 => NaiveDate::from_ymd(year + 1, 1, 1),
+            m => NaiveDate::from_ymd(year, m as u32 + 2, 1),
+        };
+
+        date.and_hms(0, 0, 0)
     }
 }
 

--- a/src/cohorthist.rs
+++ b/src/cohorthist.rs
@@ -118,9 +118,9 @@ impl CohortHist
         }
     }
 
-    pub fn set_cohort_name(&mut self, cohort: i32, name: &String)
+    pub fn set_cohort_name(&mut self, cohort: i32, name: &str)
     {
-        self.cohort_names.insert(cohort, name.clone());
+        self.cohort_names.insert(cohort, name.to_string());
     }
 
     pub fn get_cohort_name(&self, cohort: i32) -> String

--- a/src/cohorthist.rs
+++ b/src/cohorthist.rs
@@ -332,4 +332,51 @@ mod tests {
             NaiveDate::from_ymd(2021, 1, 1).and_hms(0, 0, 0),
         );
     }
+
+    #[test]
+    fn empty_cohort_hist_bounds() {
+        let hist = CohortHist::new();
+
+        assert!(hist.get_bounds().is_none());
+    }
+
+    #[test]
+    fn cohort_hist_bounds() {
+        let mut hist = CohortHist::new();
+
+        hist.set_value(YearMonth { year: 2020, month: 0 }, 0, 0);
+        hist.set_value(YearMonth { year: 2020, month: 1 }, 1, 1);
+        hist.set_value(YearMonth { year: 2020, month: 2 }, 2, 2);
+
+        let (first_ym, last_ym, first_cohort, last_cohort) = hist.get_bounds().unwrap();
+        assert_eq!(
+            (first_ym, last_ym, first_cohort, last_cohort),
+            (
+                YearMonth { year: 2020, month: 0 },
+                YearMonth { year: 2020, month: 2 },
+                0,
+                2,
+            ),
+        );
+    }
+
+    #[test]
+    fn cohort_hist_bounds_empty_months() {
+        let mut hist = CohortHist::new();
+
+        hist.set_value(YearMonth { year: 2020, month: NO_MONTH }, 0, 0);
+        hist.set_value(YearMonth { year: 2020, month: NO_MONTH }, 1, 1);
+        hist.set_value(YearMonth { year: 2020, month: NO_MONTH }, 2, 2);
+
+        let (first_ym, last_ym, first_cohort, last_cohort) = hist.get_bounds().unwrap();
+        assert_eq!(
+            (first_ym, last_ym, first_cohort, last_cohort),
+            (
+                YearMonth { year: 2020, month: NO_MONTH },
+                YearMonth { year: 2020, month: NO_MONTH },
+                0,
+                2,
+            ),
+        );
+    }
 }

--- a/src/cohorthist.rs
+++ b/src/cohorthist.rs
@@ -22,6 +22,7 @@
  * CohortHist *
  * ---------- */
 
+use itertools::{Itertools, MinMaxResult};
 use std::collections::HashMap;
 use chrono::{NaiveDate, NaiveDateTime};
 use serde::{Deserialize};
@@ -134,24 +135,10 @@ impl CohortHist
 
     pub fn get_bounds(&self) -> Option<(YearMonth, YearMonth, i32, i32)>
     {
-        let mut first_ym = YearMonth { year: i32::MAX, month: i32::MAX };
-        let mut last_ym = YearMonth { year: i32::MIN, month: i32::MIN };
-
-        for ym in self.bins.keys()
-        {
-            if ym < &first_ym
-            {
-                first_ym = *ym;
-                if last_ym < first_ym { last_ym = first_ym; }
-            }
-
-            if ym > &last_ym { last_ym = *ym; }
-        }
-
-        match first_ym
-        {
-            YearMonth { year: i32::MAX, month: i32::MAX } => { None },
-            _ => { Some((first_ym, last_ym, self.first_cohort, self.last_cohort)) }
+        match self.bins.keys().minmax() {
+            MinMaxResult::NoElements => None,
+            MinMaxResult::OneElement(&ym) => Some((ym, ym, self.first_cohort, self.last_cohort)),
+            MinMaxResult::MinMax(&min, &max) => Some((min, max, self.first_cohort, self.last_cohort)),
         }
     }
 

--- a/src/commitdb.rs
+++ b/src/commitdb.rs
@@ -86,7 +86,7 @@ impl CommitDb
         Ok(CommitDb { conn })
     }
 
-    fn email_to_domain(&self, email: &String) -> String
+    fn email_to_domain(&self, email: &str) -> String
     {
         let mut email: String = email.to_lowercase();
 
@@ -287,7 +287,7 @@ impl CommitDb
         Ok(())
     }
 
-    pub fn get_last_author_time(&mut self, repo_name: &String) -> DateTime<Utc>
+    pub fn get_last_author_time(&mut self, repo_name: &str) -> DateTime<Utc>
     {
         let mut stmt = self.conn.prepare("
             select author_time from raw_commits

--- a/src/commitdb.rs
+++ b/src/commitdb.rs
@@ -394,8 +394,9 @@ fn email_to_domain(email: &str) -> String
 
     // Strip local part.
 
-    let p = email.rfind('@');
-    if p.is_some() { email = String::from(&email[p.unwrap() + 1..]); }
+    if let Some(p) = email.rfind('@') {
+        email.replace_range(0..=p, "");
+    }
 
     // Trim the domain as much as possible. If the last element looks
     // like a country code and the next-to-last one is 2-3 letters, it's

--- a/src/commitdb.rs
+++ b/src/commitdb.rs
@@ -83,12 +83,7 @@ impl CommitDb
             create index index_committer_time on raw_commits (committer_time);
         ", NO_PARAMS).chain_err(|| "Failed to create tables")?;
 
-        let cdb: CommitDb = CommitDb
-        {
-            conn: conn,
-        };
-
-        Ok(cdb)
+        Ok(CommitDb { conn })
     }
 
     fn email_to_domain(&self, email: &String) -> String

--- a/src/commitdb.rs
+++ b/src/commitdb.rs
@@ -25,7 +25,7 @@
 use chrono::prelude::Utc;
 use chrono::{ Datelike, DateTime, NaiveDateTime };
 use rusqlite::{ Connection, NO_PARAMS };
-use crate::cohorthist::{ CohortHist, NO_COHORT, NO_MONTH, YearMonth };
+use crate::cohorthist::{ CohortHist, NO_COHORT, YearMonth };
 use crate::common::{ CohortType, IntervalType, UnitType };
 use crate::errors::*;
 use crate::gitcommitreader::RawCommit;
@@ -299,7 +299,7 @@ impl CommitDb
                 IntervalType::Year =>
                 {
                     hist.set_value(YearMonth { year:  r.get(0).unwrap(),
-                                               month: NO_MONTH },
+                                               month: None },
                                    r.get(1).unwrap(), r.get(2).unwrap());
                     hist.set_cohort_name(r.get(1).unwrap(), &r.get::<_, i32>(1).unwrap().to_string());
                 }
@@ -354,7 +354,7 @@ impl CommitDb
                 IntervalType::Year =>
                 {
                     hist.set_value(YearMonth { year:  r.get(0).unwrap(),
-                                               month: NO_MONTH },
+                                               month: None },
                                    r.get(1).unwrap(), r.get(2).unwrap());
                     hist.set_cohort_name(r.get(1).unwrap(), &r.get::<_, String>(3).unwrap());
                 }

--- a/src/commitdb.rs
+++ b/src/commitdb.rs
@@ -439,3 +439,13 @@ fn email_to_domain(email: &str) -> String
         email
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_email_username() {
+        assert_eq!(email_to_domain("dude@lebowski.com"), "lebowski.com");
+    }
+}

--- a/src/gitcommitreader.rs
+++ b/src/gitcommitreader.rs
@@ -56,7 +56,7 @@ pub struct GitCommitReader
 
 impl GitCommitReader
 {
-    pub fn new(repo_path: std::path::PathBuf, repo_name: &String, since: DateTime<Utc>) -> Result<GitCommitReader>
+    pub fn new(repo_path: std::path::PathBuf, repo_name: &str, since: DateTime<Utc>) -> Result<GitCommitReader>
     {
         let repo_path = repo_path.canonicalize().unwrap();
         let stdout = Command::new("git")
@@ -81,7 +81,7 @@ impl GitCommitReader
 
         let gcr: GitCommitReader = GitCommitReader
         {
-            repo_name: repo_name.clone(),
+            repo_name: repo_name.to_string(),
             insertions_re: Regex::new(r"([0-9]+) insertions?").unwrap(),
             deletions_re: Regex::new(r"([0-9]+) deletions?").unwrap(),
             commit_re: Regex::new(r"^[0-9a-f]+__sep__").unwrap(),

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -108,7 +108,7 @@ impl Plotter
 {
     pub fn plot_yearly_cohorts(&self,
                                meta: &ProjectMeta,
-                               unit: &String,
+                               unit: &str,
                                hist: &CohortHist, out_file: &PathBuf,
                                first_year: Option<i32>, last_year: Option<i32>) -> Result<()>
     {
@@ -191,7 +191,7 @@ EOD
 
     pub fn plot_monthly_cohorts(&self,
                                 meta: &ProjectMeta,
-                                unit: &String,
+                                unit: &str,
                                 hist: &CohortHist, out_file: &PathBuf,
                                 first_year: Option<i32>, last_year: Option<i32>) -> Result<()>
     {

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -113,15 +113,11 @@ impl Plotter
                                first_year: Option<i32>, last_year: Option<i32>) -> Result<()>
     {
         let bounds = hist.get_bounds().unwrap();
-        let first_year =
-            if first_year.is_some() { first_year.unwrap() }
-            else if meta.first_year.is_some() { meta.first_year.unwrap() }
-            else { bounds.0.year };
-        let last_year =
-            if last_year.is_some() { last_year.unwrap() }
-            else if meta.last_year.is_some() { meta.last_year.unwrap() }
-            else if bounds.0.year == bounds.1.year { bounds.1.year }
-            else { bounds.1.year - 1 };
+        let first_year = first_year.or(meta.first_year).unwrap_or(bounds.0.year);
+        let last_year = last_year.or(meta.last_year).unwrap_or_else(|| {
+            if bounds.0.year == bounds.1.year { bounds.1.year }
+            else { bounds.1.year - 1 }
+        });
         let markers = meta.markers_to_gnuplot();
         let gnuplot_cmd = format!("
             {}

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -120,16 +120,16 @@ impl Plotter
         });
         let markers = meta.markers_to_gnuplot();
         let gnuplot_cmd = format!("
-            {}
-            set style line {} lt 1 lc rgb '#ffffd0';
+            {gnuplot_setup}
+            set style line {last_style_num} lt 1 lc rgb '#ffffd0';
 $data << EOD
-{}
+{history}
 EOD
-            set output \"{}\";
-            set ylabel \"{}\";
-            set xrange [{}:{}];
+            set output \"{output}\";
+            set ylabel \"{ylabel}\";
+            set xrange [{xrange_0}:{xrange_1}];
             set multiplot;
-            plot for [i=3:{}] '$data' using i:xtic(stringcolumn(1)) ls i-2 title columnheader(i);
+            plot for [i=3:{plot_range}] '$data' using i:xtic(stringcolumn(1)) ls i-2 title columnheader(i);
             unset key;
             set style data histep;
             set xtics textcolor rgb \"0xff000000\" scale 1 0.5,1;
@@ -137,21 +137,21 @@ EOD
             set grid xtics ytics front linestyle 101;
             set yrange restore;
             set style textbox opaque noborder;
-            {}
-            {}
+            {markers}
+            {markers_extra}
             plot '$data' using 2 lc rgb 'black' lw 2 notitle;
             unset multiplot;
             ",
-            GNUPLOT_COHORTS_COMMON,
-            hist.get_n_bins() + 1,
-            &hist.to_csv(),
-            out_file.to_string_lossy().into_owned(),
-            unit,
-            (first_year - bounds.0.year) as f32 - 0.5,
-            (last_year - bounds.0.year) as f32 + 0.5,
-            hist.get_n_bins() + 3,
-            &markers.0,
-            if markers.1 > 0
+            gnuplot_setup = GNUPLOT_COHORTS_COMMON,
+            last_style_num = hist.get_n_bins() + 1,
+            history = &hist.to_csv(),
+            output = out_file.to_string_lossy().into_owned(),
+            ylabel = unit,
+            xrange_0 = (first_year - bounds.0.year) as f32 - 0.5,
+            xrange_1 = (last_year - bounds.0.year) as f32 + 0.5,
+            plot_range = hist.get_n_bins() + 3,
+            markers = &markers.0,
+            markers_extra = if markers.1 > 0
             {
                 format!("
                     set for [i=0:{}:1] label left markers[int(i)*4+4] \
@@ -202,16 +202,16 @@ EOD
             else { bounds.1.year };
         let markers = meta.markers_to_gnuplot();
         let gnuplot_cmd = format!("
-            {}
-            set style line {} lt 1 lc rgb '#ffffd0';
+            {gnuplot_setup}
+            set style line {last_style_num} lt 1 lc rgb '#ffffd0';
 $data << EOD
-{}
+{history}
 EOD
-            set output \"{}\";
-            set ylabel \"{}\";
-            set xrange [{}:{}];
+            set output \"{output}\";
+            set ylabel \"{ylabel}\";
+            set xrange [{xrange_0}:{xrange_1}];
             set multiplot;
-            plot for [i=4:{}] '$data' using i:xtic($2==\"06\" \
+            plot for [i=4:{plot_range}] '$data' using i:xtic($2==\"06\" \
                 ? stringcolumn(1) : \"\") ls i-3 title columnheader(i);
             unset key;
             set style data histep;
@@ -221,21 +221,21 @@ EOD
             set grid xtics ytics front linestyle 101;
             set yrange restore;
             set style textbox opaque noborder;
-            {}
-            {}
+            {markers}
+            {markers_extra}
             plot '$data' using 3 lc rgb 'black' lw 2 notitle;
             unset multiplot;
             ",
-            GNUPLOT_COHORTS_COMMON,
-            hist.get_n_bins() + 1,
-            &hist.to_csv(),
-            out_file.to_string_lossy().into_owned(),
-            unit,
-            ((first_year - bounds.0.year) * 12) as f32 - 0.5,
-            ((last_year - bounds.0.year) * 12 + 12) as f32 - 0.5,
-            hist.get_n_bins() + 4,
-            &markers.0,
-            if markers.1 > 0
+            gnuplot_setup = GNUPLOT_COHORTS_COMMON,
+            last_style_num = hist.get_n_bins() + 1,
+            history = &hist.to_csv(),
+            output = out_file.to_string_lossy().into_owned(),
+            ylabel = unit,
+            xrange_0 = ((first_year - bounds.0.year) * 12) as f32 - 0.5,
+            xrange_1 = ((last_year - bounds.0.year) * 12 + 12) as f32 - 0.5,
+            plot_range = hist.get_n_bins() + 4,
+            markers = &markers.0,
+            markers_extra = if markers.1 > 0
             {
                 format!("
                     set for [i=0:{}:1] label left markers[int(i)*4+4] \

--- a/src/projectmeta.rs
+++ b/src/projectmeta.rs
@@ -128,7 +128,7 @@ impl ProjectMeta
             + &self.markers.as_ref().unwrap().iter()
                 .map(|m| { n_markers += 1;
                            format!("'{}', '{:02}', {}, '{}',",
-                                   m.time.year, m.time.month, m.row, m.text) })
+                                   m.time.year, m.time.month.unwrap_or(-1), m.row, m.text) })
                 .collect::<Vec<String>>().join(" ")
             + &" ];".to_string(),
          n_markers)

--- a/src/statuslogger.rs
+++ b/src/statuslogger.rs
@@ -51,9 +51,9 @@ impl StatusLogger
         }
     }
 
-    pub fn begin_repo(&mut self, repo_name: &String)
+    pub fn begin_repo(&mut self, repo_name: &str)
     {
-        self.repo_name = repo_name.clone();
+        self.repo_name = repo_name.to_string();
         self.n_commits = 0;
         self.last_timestamp = 0;
         self.last_year = 0;


### PR DESCRIPTION
Fixes most of the clippy lints except for the brace placement.  (protip: just let cargo-fmt do its thing and add `#[rustfmt::skip]` where you disagree for hand-aligned stuff...)

Also replaces `YearMonth.month` with an Option, and uses itertools's `minmax()` instead of implementing that by hand.  Adds some tests for the functional changes.
