### PR TITLE
support bare directories, respect the .mailmap file

### DIFF
--- a/src/gitcommitreader.rs
+++ b/src/gitcommitreader.rs
@@ -60,9 +60,7 @@ impl GitCommitReader
     {
         let repo_path = repo_path.canonicalize().unwrap();
         let stdout = Command::new("git")
-            .arg("--git-dir")
-            .arg(repo_path.join(".git"))
-            .arg("--work-tree")
+            .arg("-C")
             .arg(&repo_path)
             .arg("log")
             .arg("--branches")

--- a/src/gitcommitreader.rs
+++ b/src/gitcommitreader.rs
@@ -65,7 +65,7 @@ impl GitCommitReader
             .arg("log")
             .arg("--branches")
             .arg("--remotes")
-            .arg("--pretty=format:%H__sep__%aD__sep__%an__sep__%ae__sep__%cD__sep__%cn__sep__%ce")
+            .arg("--pretty=format:%H__sep__%aD__sep__%aN__sep__%aE__sep__%cD__sep__%cN__sep__%cE")
             .arg("--reverse")
             .arg("--since")
             .arg(since.to_rfc2822())


### PR DESCRIPTION
The two commits in this PR enable support for bare directories, and ensure that the `.mailmap` file of the ingested directory is respected. The latter change fixes an important inaccuracy in fornalder for repositories where a SVN->git conversion (typically) changed all author names at once.

The main change is to replace the use of `git --git-dir foo/.git --work-tree foo/ log` by  `git -C foo log`. In my testing, this works just as well (and is instrumental in fixing the two issues mentioned above), but I'm not familiar with either of these three options so there may be side-effects that I don't know about.