### PR TITLE
ProjectMeta: Specify array size when initializing markers array

### DIFF
--- a/src/projectmeta.rs
+++ b/src/projectmeta.rs
@@ -124,7 +124,7 @@ impl ProjectMeta
 
         let mut n_markers = 0;
 
-        ("array markers = [ ".to_string()
+        (format!("array markers[{}] = [ ", self.markers.as_ref().unwrap().len() * 4)
             + &self.markers.as_ref().unwrap().iter()
                 .map(|m| { n_markers += 1;
                            format!("'{}', '{:02}', {}, '{}',",


### PR DESCRIPTION
Allows to be compatible with Gnuplot < 5.2.5
(Ubuntu 18.04 uses 5.2.2)
The automatic deduction was added in 5.2.5:
"NEW array size can be determined automatically from the initializer" http://www.gnuplot.info/ReleaseNotes_5_2_5.html