### PR TITLE
Plotter: add noenhanced option to key

### DIFF
--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -95,7 +95,7 @@ set style data histogram;
 set style histogram rowstacked;
 set xtics scale 0 nomirror offset 0,graph 0.015;
 set ytics nomirror;
-set key autotitle columnheader;
+set key autotitle columnheader noenhanced;
 set key reverse Left horizontal nobox bmargin left width 1.1;
 set ytics textcolor rgb \"0xff000000\" scale 0;
 ";


### PR DESCRIPTION
To avoid subscript if the name contains an underscore

Before:
![image](https://user-images.githubusercontent.com/8845664/209314289-4e327d89-6826-4064-974e-befb06b9ba82.png)

After:
![image](https://user-images.githubusercontent.com/8845664/209314325-50b8b692-108d-4a62-8dc4-65d8da9b650a.png)
